### PR TITLE
Add traefik-swarm profile

### DIFF
--- a/profiles/traefik-swarm
+++ b/profiles/traefik-swarm
@@ -1,0 +1,11 @@
+# Profile for Traefik with assisting logrotate container running in docker swarm.
+# The profile allows the logrotate to POST USR1 signal to notify Traefik
+# to recreate/reopen log files.
+
+### Read only operations ###
+HEAD        /_ping
+GET         /(v\d+(\\)?\.\d+/)(version|services|networks|tasks|events)(\\?.*|/.*)?
+GET         /(v\d+(\\)?\.\d+/)containers/json(\\?.*|/.*)?
+
+### Allow to send USR1 signal ###
+POST        /(v\d+(\\)?\.\d+)/containers/([a-z0-9]+)/kill\?signal=USR1


### PR DESCRIPTION
Profile for Traefik with assisting logrotate container (for example `vegardit/docker-traefik-logrotate`) running in docker swarm.
The profile allows the logrotate to POST USR1 signal to notify Traefik to recreate/reopen log files.