### PR TITLE
Add missing response for nodes

### DIFF
--- a/profiles/traefik-swarm
+++ b/profiles/traefik-swarm
@@ -4,7 +4,7 @@
 
 ### Read only operations ###
 HEAD        /_ping
-GET         /(v\d+\.\d+/)(version|services|networks|tasks|events)(\?.*|/.*)?
+GET         /(v\d+\.\d+/)(version|services|networks|tasks|events|nodes)(\?.*|/.*)?
 GET         /(v\d+\.\d+/)containers/json(\?.*|/.*)?
 
 ### Allow to send USR1 signal ###


### PR DESCRIPTION
New Traefik (3.5.1) requires an extra GET: `nodes`.

Without it, Traefik throws this error:

```
[90m2025-08-31T14:48:56+10:00[0m [33mWRN[0m [1mError while parsing task [0m [36merror=[0m[31m[1m"inspecting node jcghcmgcgc6lkr1tmq9h5748d: Error response from daemon: request denied: GET /v1.24/nodes/jcghcmgcgc6lkr1tmq9h5748d"[0m[0m [36mproviderName=[0mswarm                                                                                                            
```